### PR TITLE
Send messages from PowerShell -> Bot -> IRC channel

### DIFF
--- a/Out-IrcBot.ps1
+++ b/Out-IrcBot.ps1
@@ -1,0 +1,44 @@
+<#
+.Synopsis
+   Reads text from the pipeline, and sends it to an IRC channel 
+   via a named pipe -- to --> Run-IrcBot.ps1 
+.DESCRIPTION
+   Long description
+.EXAMPLE
+   PS C:\> 'Hello World' | .\Out-IrcBot.ps1
+.EXAMPLE
+   PS C:\> Get-Content test.txt | .\Out-IrcBot.ps1
+#>
+[CmdletBinding()]
+[Alias()]
+Param
+(
+    # The text to send to IRC
+    [Parameter(Mandatory=$true,
+                ValueFromPipeline=$true)]
+    [String]$Text
+)
+
+Process
+{
+    # Create and connect to a pipe
+    # (This end is asynchronous and message based because the other end needs to be, and this matches it)
+    # Pipe is 'InOut' direction because if you just specify a one-way pipe, you can't 
+    # make it 'Message' type, unless you manually specify the permissions. This is easier.
+    Write-Host -ForegroundColor Cyan "Writing: $Text"
+
+    $pipe = New-Object System.IO.Pipes.NamedPipeClientStream('.',                      #computer
+                                                                'ircbot_pipe',            #pipe name
+                                                                [System.IO.Pipes.PipeDirection]::InOut,
+                                                                [System.IO.Pipes.PipeOptions]::Asynchronous)
+
+        
+    $pipe.Connect(10000) #10,000 milisecond connection timeout
+    $pipe.ReadMode = [System.IO.Pipes.PipeTransmissionMode]::Message     # can't specify in ctor
+                                                               
+    # Convert the text to a byte array and send it                        
+    $Message = [System.Text.Encoding]::UTF8.GetBytes($Text)
+    $pipe.write($Message, 0, $Message.Length)
+
+    $pipe.Dispose()
+}

--- a/README.md
+++ b/README.md
@@ -250,6 +250,20 @@ You can also use the command-line option to use another script or pass arguments
 .\Run-IrcBot.ps1 awesomebot ircserver channel superbot
 .\Run-IrcBot.ps1 awesomebot ircserver channel { .\superbot.ps1 $Message $Bot -DoAwesomeStuff }
 ```
+### Sending text from PowerShell to IRC
+
+Use this to make the bot 'speak' in IRC, triggered by a local PowerShell script.
+e.g. once the bot is running, open a new PowerShell window and:
+
+```PowerShell
+echo 'Hello World!' | .\Out-IrcBot.ps1
+```
+The bot will say 'Hello World' into the first IRC channel it's joined to. You could use this to notify an IRC channel of the results of a command:
+
+```PowerShell
+Get-Content test.txt | .\Out-IrcBot.ps1
+```
+This works by Run-IrcBot.ps1 keeping a named pipe open, and Out-IrcBot.ps1 reading from the pipeline and writing to the named pipe.
 
 ## Specification
 


### PR DESCRIPTION
This pull request adds a way to send text from a PowerShell session, through the bot, and out to IRC.

The main change is to Run-IrcBot.ps1, adding a function to keep a named pipe listener running, asynchronously in the background, and a call inside the main loop to process it.

And there's a helper script, and an update to the readme to give examples.
